### PR TITLE
Update Cascade and Sense Protocol providers

### DIFF
--- a/examples/astro-example/package.json
+++ b/examples/astro-example/package.json
@@ -18,6 +18,7 @@
 		"@lukso/data-provider-ipfs-http-client": "workspace:*",
 		"@lukso/data-provider-pinata": "workspace:*",
 		"@lukso/data-provider-cascade": "workspace:*",
+		"@lukso/data-provider-sense": "workspace:*",
 		"@lukso/data-provider-urlresolver": "workspace:*",
 		"@types/react": "^18.2.73",
 		"@types/react-dom": "^18.2.23",

--- a/examples/astro-example/package.json
+++ b/examples/astro-example/package.json
@@ -17,6 +17,7 @@
 		"@astrojs/vue": "^4.0.9",
 		"@lukso/data-provider-ipfs-http-client": "workspace:*",
 		"@lukso/data-provider-pinata": "workspace:*",
+		"@lukso/data-provider-cascade": "workspace:*",
 		"@lukso/data-provider-urlresolver": "workspace:*",
 		"@types/react": "^18.2.73",
 		"@types/react-dom": "^18.2.23",

--- a/examples/astro-example/src/components/UploadCascade.tsx
+++ b/examples/astro-example/src/components/UploadCascade.tsx
@@ -1,0 +1,39 @@
+import { CascadeUploader } from "@lukso/data-provider-cascade";
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import { urlResolver } from "./shared";
+
+export default function UploadPinata() {
+	const provider = useMemo(
+		() =>
+			new CascadeUploader(import.meta.env.CASCADE_API_KEY),
+		[],
+	);
+
+	const fileInput = useRef<HTMLInputElement>(null);
+	const [url, setUrl] = useState("");
+	const [resultId, setResultId] = useState("");
+	const [imageUrl, setImageUrl] = useState("");
+
+	const upload = useCallback(async () => {
+		const file = fileInput?.current?.files?.item(0) as File;
+		const { ipfs_url: url, result_id } = await provider.uploadToCascade(file);
+		setUrl(url);
+		setResultId(result_id);
+		const imageUrl = urlResolver.resolveUrl(url);
+		setImageUrl(imageUrl);
+	}, [provider.upload]);
+
+	return (
+		<div>
+			<input ref={fileInput} type="file" accept="image/*" />
+			<button type="button" onClick={upload}>
+				Upload
+			</button>
+			<div className="url">Url: {url}</div>
+			<div className="hash">Result Id: {resultId}</div>
+			<div>
+				<img className="image" src={imageUrl} alt="uploaded" />
+			</div>
+		</div>
+	);
+}

--- a/examples/astro-example/src/components/UploadSense.tsx
+++ b/examples/astro-example/src/components/UploadSense.tsx
@@ -1,0 +1,39 @@
+import { SenseUploader } from "@lukso/data-provider-sense";
+import React, { useCallback, useMemo, useRef, useState } from "react";
+import { urlResolver } from "./shared";
+
+export default function UploadPinata() {
+	const provider = useMemo(
+		() =>
+			new SenseUploader(import.meta.env.SENSE_API_KEY),
+		[],
+	);
+
+	const fileInput = useRef<HTMLInputElement>(null);
+	const [url, setUrl] = useState("");
+	const [resultId, setResultId] = useState("");
+	const [imageUrl, setImageUrl] = useState("");
+
+	const upload = useCallback(async () => {
+		const file = fileInput?.current?.files?.item(0) as File;
+		const { ipfs_url: url, result_id } = await provider.uploadToSense(file);
+		setUrl(url);
+		setResultId(result_id);
+		const imageUrl = urlResolver.resolveUrl(url);
+		setImageUrl(imageUrl);
+	}, [provider.upload]);
+
+	return (
+		<div>
+			<input ref={fileInput} type="file" accept="image/*" />
+			<button type="button" onClick={upload}>
+				Upload
+			</button>
+			<div className="url">Url: {url}</div>
+			<div className="hash">Result Id: {resultId}</div>
+			<div>
+				<img className="image" src={imageUrl} alt="uploaded" />
+			</div>
+		</div>
+	);
+}

--- a/examples/astro-example/src/components/UploadVueCascade.vue
+++ b/examples/astro-example/src/components/UploadVueCascade.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <input ref="fileInput" type="file" accept="image/*" />
+    <button @click="upload">Upload</button>
+    <div className="url">{{ url }}</div>
+    <div className="hash">{{ resultId }}</div>
+    <div>
+      <img className="image" :src="imageUrl" alt="uploaded image" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Hash } from "node:crypto";
+import { CascadeUploader } from "@lukso/data-provider-cascade";
+import { ref } from "vue";
+import { urlResolver } from "./shared";
+
+const url = ref("");
+const resultId = ref("");
+const imageUrl = ref("");
+const fileInput = ref<HTMLInputElement | null>(null);
+
+const provider = new CascadeUploader(import.meta.env.CASCADE_API_KEY);
+
+const upload = async () => {
+	const file = fileInput.value?.files?.item(0) as File;
+	const formData = new FormData();
+	formData.append("file", file); // FormData keys are called fields
+	const info = await provider.upload(file);
+	url.value = info.ipfs_url;
+	resultId.value = info.result_id;
+	imageUrl.value = urlResolver.resolveUrl(url.value);
+};
+</script>

--- a/examples/astro-example/src/components/UploadVueSense.vue
+++ b/examples/astro-example/src/components/UploadVueSense.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <input ref="fileInput" type="file" accept="image/*" />
+    <button @click="upload">Upload</button>
+    <div className="url">{{ url }}</div>
+    <div className="hash">{{ resultId }}</div>
+    <div>
+      <img className="image" :src="imageUrl" alt="uploaded image" />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Hash } from "node:crypto";
+import { SenseUploader } from "@lukso/data-provider-sense";
+import { ref } from "vue";
+import { urlResolver } from "./shared";
+
+const url = ref("");
+const resultId = ref("");
+const imageUrl = ref("");
+const fileInput = ref<HTMLInputElement | null>(null);
+
+const provider = new SenseUploader(import.meta.env.SENSE_API_KEY);
+
+const upload = async () => {
+	const file = fileInput.value?.files?.item(0) as File;
+	const formData = new FormData();
+	formData.append("file", file); // FormData keys are called fields
+	const info = await provider.upload(file);
+	url.value = info.ipfs_url;
+	resultId.value = info.result_id;
+	imageUrl.value = urlResolver.resolveUrl(url.value);
+};
+</script>

--- a/examples/astro-example/src/pages/api-cascade.ts
+++ b/examples/astro-example/src/pages/api-cascade.ts
@@ -1,0 +1,17 @@
+import { CascadeUploader } from "@lukso/data-provider-cascade";
+import type { APIContext } from "astro";
+
+// File routes export a get() function, which gets called to generate the file.
+// Return an object with `body` to save the file contents in your final build.
+// If you export a post() function, you can catch post requests, and respond accordingly
+export async function POST({ request }: APIContext) {
+	const formData = await request.formData();
+	const file = formData.get("file");
+
+	const provider = new CascadeUploader(process.env.CASCADE_API_KEY);
+
+	const result = await provider.uploadToCascade(file);
+	return new Response(JSON.stringify({ Hash: result.ipfs_url }), {
+		headers: { contentType: "application/json" },
+	});
+}

--- a/examples/astro-example/src/pages/api-sense.ts
+++ b/examples/astro-example/src/pages/api-sense.ts
@@ -1,0 +1,17 @@
+import { SenseUploader } from "@lukso/data-provider-sense";
+import type { APIContext } from "astro";
+
+// File routes export a get() function, which gets called to generate the file.
+// Return an object with `body` to save the file contents in your final build.
+// If you export a post() function, you can catch post requests, and respond accordingly
+export async function POST({ request }: APIContext) {
+	const formData = await request.formData();
+	const file = formData.get("file");
+
+	const provider = new SenseUploader(process.env.SENSE_API_KEY);
+
+	const result = await provider.uploadToSense(file);
+	return new Response(JSON.stringify({ Hash: result.ipfs_url }), {
+		headers: { contentType: "application/json" },
+	});
+}

--- a/examples/astro-example/src/pages/index.astro
+++ b/examples/astro-example/src/pages/index.astro
@@ -4,8 +4,12 @@ import Card from "../components/Card.astro";
 import ReactCard from "../components/ReactCard.tsx";
 import Upload from "../components/Upload.tsx";
 import UploadPinata from "../components/UploadPinata.tsx";
+import UploadCascade from "../components/UploadCascade.tsx";
+import UploadSense from "../components/UploadSense.tsx";
 import UploadVue from "../components/UploadVue.vue";
 import UploadVuePinata from "../components/UploadVuePinata.vue";
+import UploadVueCascade from "../components/UploadVueCascade.vue";
+import UploadVueSense from "../components/UploadVueSense.vue";
 import VueCard from "../components/VueCard.vue";
 import Layout from "../layouts/Layout.astro";
 ---
@@ -56,6 +60,12 @@ import Layout from "../layouts/Layout.astro";
           }
         }}/>
       </ReactCard>
+			<ReactCard color="white" title="Upload to Cascade" client:only="react">
+        <UploadCascade client:only="react"/>
+      </ReactCard>
+			<ReactCard color="white" title="Upload to Sense" client:only="react">
+        <UploadSense client:only="react"/>
+      </ReactCard>
 
       <li><h3>Frontend Vue</h3></li>
       <VueCard color="white" title="Upload to Local" client:only="vue">
@@ -71,6 +81,12 @@ import Layout from "../layouts/Layout.astro";
           }
         }}/>
       </VueCard>
+			<VueCard color="white" title="Upload to Cascade" client:only="vue">
+        <UploadVueCascade client:only="vue"/>
+      </VueCard>
+			<VueCard color="white" title="Upload to Sense" client:only="vue">
+        <UploadVueSense client:only="vue"/>
+      </VueCard>
 
       <li><h3>Backend React</h3></li>
       <ReactCard color="white" title="Upload to Local" client:only="react">
@@ -82,6 +98,12 @@ import Layout from "../layouts/Layout.astro";
       <ReactCard color="white" title="Upload to Infura" client:only="react">
         <Upload client:only="react" gateway="/api-infura"/>
       </ReactCard>
+      <ReactCard color="white" title="Upload to Cascade" client:only="react">
+        <Upload client:only="react" gateway="/api-cascade"/>
+      </ReactCard>
+      <ReactCard color="white" title="Upload to Sense" client:only="react">
+        <Upload client:only="react" gateway="/api-sense"/>
+      </ReactCard>
 
       <li><h3>Backend Vue</h3></li>
       <VueCard color="white" title="Upload to Local" client:only="vue">
@@ -92,6 +114,12 @@ import Layout from "../layouts/Layout.astro";
       </VueCard>
       <VueCard color="white" title="Upload to Infura" client:only="vue">
         <UploadVue client:only="vue" gateway="/api-infura"/>
+      </VueCard>
+			<VueCard color="white" title="Upload to Cascade" client:only="vue">
+        <UploadVue client:only="vue" gateway="/api-cascade"/>
+      </VueCard>
+      <VueCard color="white" title="Upload to Sense" client:only="vue">
+        <UploadVue client:only="vue" gateway="/api-sense"/>
       </VueCard>
 		</ul>
 	</main>

--- a/examples/upload-cascade.mjs
+++ b/examples/upload-cascade.mjs
@@ -19,3 +19,16 @@ if (result) {
   const status = await provider.retrieveTxId(result.result_id);
   console.log(status); // { status: "PENDING" or "SUCCESS", tx_id: activation_transaction_id }
 }
+
+// upload folder
+const results = await provider.uploadFolderToCascade("./examples");
+
+if (results.length > 0) {
+  for (const result of results) {
+    if (result) {
+      console.log("File Name:", result.file_name);
+      console.log("IPFS Url:", result.ipfs_url);
+      console.log("Result Id:", result.result_id);
+    }
+  }
+}

--- a/examples/upload-cascade.mjs
+++ b/examples/upload-cascade.mjs
@@ -1,0 +1,21 @@
+import { createReadStream } from "node:fs";
+import { CascadeUploader } from "@lukso/data-provider-cascade";
+import { config } from "dotenv";
+
+config({ path: "./.env.test" });
+
+const provider = new CascadeUploader(
+	process.env.CASCADE_API_KEY || ""
+);
+
+const file = createReadStream("./examples/test-image.png");
+
+const result = await provider.uploadToCascade(file);
+
+if (result) {
+  console.log(result.ipfs_url);
+
+  // Get transaction status
+  const status = await provider.retrieveTxId(result.result_id);
+  console.log(status); // { status: "PENDING" or "SUCCESS", tx_id: activation_transaction_id }
+}

--- a/examples/upload-sense.mjs
+++ b/examples/upload-sense.mjs
@@ -19,3 +19,16 @@ if (result) {
   const status = await provider.retrieveTxId(result.result_id);
   console.log(status); // { status: "PENDING" or "SUCCESS", tx_id: activation_transaction_id }
 }
+
+// upload folder
+const results = await provider.uploadFolderToSense("./examples");
+
+if (results.length > 0) {
+  for (const result of results) {
+    if (result) {
+      console.log("File Name:", result.file_name);
+      console.log("IPFS Url:", result.ipfs_url);
+      console.log("Result Id:", result.result_id);
+    }
+  }
+}

--- a/examples/upload-sense.mjs
+++ b/examples/upload-sense.mjs
@@ -1,0 +1,21 @@
+import { createReadStream } from "node:fs";
+import { SenseUploader } from "@lukso/data-provider-sense";
+import { config } from "dotenv";
+
+config({ path: "./.env.test" });
+
+const provider = new SenseUploader(
+	process.env.SENSE_API_KEY || ""
+);
+
+const file = createReadStream("./examples/test-image.png");
+
+const result = await provider.uploadToSense(file);
+
+if (result) {
+  console.log(result.ipfs_url);
+
+  // Get transaction status
+  const status = await provider.retrieveTxId(result.result_id);
+  console.log(status); // { status: "PENDING" or "SUCCESS", tx_id: activation_transaction_id }
+}

--- a/packages/data-provider-cascade/etc/data-provider-cascade.api.md
+++ b/packages/data-provider-cascade/etc/data-provider-cascade.api.md
@@ -9,11 +9,48 @@ import { FormDataPostHeaders } from '@lukso/data-provider-base';
 import { FormDataRequestOptions } from '@lukso/data-provider-base';
 
 // @public (undocumented)
+export interface CascadeUploadedResult {
+    // (undocumented)
+    request_id: string;
+    // (undocumented)
+    request_status: string;
+    // (undocumented)
+    results: [
+        {
+        result_status: string;
+        file_name: string;
+        file_type: string;
+        file_id: string;
+        created_at: Date;
+        last_updated_at: Date;
+        retry_num: number;
+        registration_ticket_txid: string;
+        activation_ticket_txid: string;
+        original_file_ipfs_link: string;
+        stored_file_ipfs_link: string;
+        stored_file_aws_link: string;
+        stored_file_other_links: object;
+        make_publicly_accessible: boolean;
+        offer_ticket_txid: string;
+        offer_ticket_intended_rcpt_pastel_id: string;
+        error: string;
+        result_id: string;
+    }
+    ];
+}
+
+// @public (undocumented)
 class CascadeUploader extends BaseFormDataUploader {
     constructor(apiKey: string);
     getEndpoint(): string;
+    // (undocumented)
+    getGatewayUrl(): string;
     getRequestOptions(_dataContent: FormData, meta?: FormDataPostHeaders): Promise<FormDataRequestOptions>;
     resolveUrl(result: any): string;
+    // (undocumented)
+    retrieveTxId(result_id: string): Promise<any>;
+    // (undocumented)
+    uploadToCascade(data: any, _meta?: FormDataPostHeaders): Promise<any>;
 }
 export { CascadeUploader }
 export default CascadeUploader;

--- a/packages/data-provider-cascade/src/index.ts
+++ b/packages/data-provider-cascade/src/index.ts
@@ -1,8 +1,37 @@
 import {
 	BaseFormDataUploader,
+	getFetch,
+	getFormData,
 	type FormDataPostHeaders,
 	type FormDataRequestOptions,
 } from "@lukso/data-provider-base";
+
+export interface CascadeUploadedResult {
+  request_id: string;
+  request_status: string;
+  results: [
+    {
+      result_status: string;
+      file_name: string;
+      file_type: string;
+      file_id: string;
+      created_at: Date;
+      last_updated_at: Date;
+      retry_num: number;
+      registration_ticket_txid: string;
+      activation_ticket_txid: string;
+      original_file_ipfs_link: string;
+      stored_file_ipfs_link: string;
+      stored_file_aws_link: string;
+      stored_file_other_links: object;
+      make_publicly_accessible: boolean;
+      offer_ticket_txid: string;
+      offer_ticket_intended_rcpt_pastel_id: string;
+      error: string;
+      result_id: string;
+    }
+  ]
+}
 
 export class CascadeUploader extends BaseFormDataUploader {
 	constructor(private apiKey: string) {
@@ -27,9 +56,13 @@ export class CascadeUploader extends BaseFormDataUploader {
 			...root, 
 			headers: {
 				...root.headers,
-				"Api-key": this.apiKey,
+				"api_key": this.apiKey,
 			}
 		 };
+	}
+
+	getGatewayUrl(): string {
+		return "https://gateway-api.pastel.network/api/v1/";
 	}
 
 	/**
@@ -38,17 +71,60 @@ export class CascadeUploader extends BaseFormDataUploader {
 	 * @returns Return the endpoint to be used for cascade
 	 */
 	getEndpoint(): string {
-		return "https://gateway-api.pastel.network/api/v1/cascade?make_publicly_accessible=true";
+		return `${this.getGatewayUrl()}cascade?make_publicly_accessible=true`;
 	}
 
 	/**
-	 * Decode IPFS URL from POST results.
+	 * Uploads file to Cascade Protocol and return result id and ipfs link.
 	 *
-	 * @param result - JSON result from upload
-	 * @returns ipfs URL
+	 * @param data - data to upload
+	 * @param meta - optional metadata to send with the upload
+	 * @returns result id and ipfs URL of uploaded file
+	 * @internal
 	 */
-	resolveUrl(result: any): string {
-		return `ipfs://${result.IpfsHash}`;
+	async uploadToCascade(
+		data: any,
+		_meta?: FormDataPostHeaders,
+	): Promise<any> {
+		let meta = _meta;
+		const FormData = await getFormData();
+		const dataContent = new FormData();
+		dataContent.append("files", await this.wrapStream(data));
+		const options = await this.getRequestOptions(dataContent as FormData, meta);
+		const result: CascadeUploadedResult = await this.uploadFormData(options, dataContent as FormData);
+		if (result.results.length > 0) {
+			return {
+				result_id: result.results[0].result_id,
+				ipfs_url: result.results[0].original_file_ipfs_link
+			};
+		}
+		return null;
+	}
+
+
+	/**
+	 * Check status of cascade activation transaction at Pastel Network
+	 *
+	 * @param result_id - result id of target file
+	 * @returns transaction status and activiation ticket id
+	 * @internal
+	 */
+	async retrieveTxId(result_id: string): Promise<any> {
+		const fetch = await getFetch();
+		try {
+			const result: any = await (await fetch(`${this.getGatewayUrl()}cascade/gateway_results/${result_id}`, {
+				headers: {
+					'api_key': this.apiKey,
+				}
+			})).json();
+			return {
+				status: result.result_status,
+				tx_id: result.activation_ticket_txid
+			};
+		}
+		catch (e) {
+			return null;
+		}
 	}
 }
 


### PR DESCRIPTION
# What does this PR introduce?

Custom upload function defined for cascade and sense providers and added activation ticket check function.
And also added example codes to use providers
Folder Upload feature added too

## 🚀 Feature

### PR Checklist

- [ ] Wrote Tests
- [x] Wrote & Generated Documentation (readme/natspec/dodoc)
- [x] Ran `npm run lint` && `npm run lint:solidity` (solhint)
- [x] Ran `npm run format` (prettier)
- [x] Ran `npm run build`
- [ ] Ran `npm run test`
